### PR TITLE
ansible-lint: file-permissions need to be specified in recent ansible versions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,3 @@
+# .ansible-lint
+skip_list:
+  - '403'  # Package installs should not use latest

--- a/chapter-06/configure_nginx_web_server.yml
+++ b/chapter-06/configure_nginx_web_server.yml
@@ -26,6 +26,7 @@
       copy:
         src: index.html
         dest: /usr/share/nginx/html/index.html
+        mode: 0644
       become: true
 
     - name: start nginx service

--- a/chapter-08/configure_nginx_web_server.yml
+++ b/chapter-08/configure_nginx_web_server.yml
@@ -17,6 +17,7 @@
       copy:
         src: index.html
         dest: /usr/share/nginx/html/index.html
+        mode: 0644
       become: true
 
     - name: start nginx service


### PR DESCRIPTION
 In recent ansible-lint versions there is a security concern with file operations. Ansible-lint warns about it.
 
 I added a file to configure ansible-lint to skip complaining about installing the latest version.
 
 Fixes #17 