### PR TITLE
Corrected a few names and increased wait to 60 sec

### DIFF
--- a/chapter-03/aws/aws_delete_ansible_env.yaml
+++ b/chapter-03/aws/aws_delete_ansible_env.yaml
@@ -9,7 +9,8 @@
 
   tasks:
 
-    - ec2_vpc_net_info:
+    - name: get vpc info
+      ec2_vpc_net_info:
         region: us-east-1
         filters:
           "tag:Name": ansible
@@ -44,17 +45,18 @@
         region: us-east-1
         instance_ids: "{{ ec2_ids }}"
 
-    - name: sleep for 30 seconds
+    - name: sleep for 60 seconds
       wait_for:
-        timeout: 30
+        timeout: 60
       delegate_to: localhost
 
-    - ec2_group_info:
+    - name: get security groups info
+      ec2_group_info:
         region: us-east-1
         filters:
           group_name: 
-            - webserver
-            - redis
+            - linux
+            - windows
           vpc-id: "{{ ansible_vpc.vpcs[0].id }}"
       register: sgs
 
@@ -92,7 +94,7 @@
           env: dev
         state: absent
 
-    - name: delete route IGW
+    - name: delete route table
       ec2_vpc_route_table:
         vpc_id: "{{ ansible_vpc.vpcs[0].id }}"
         region: us-east-1

--- a/chapter-03/aws/aws_deploy_ansible_env.yaml
+++ b/chapter-03/aws/aws_deploy_ansible_env.yaml
@@ -2,7 +2,7 @@
   gather_facts: false
   connection: local
 
-- name: '[AWS] create resource group'
+- name: '[AWS] create vpc'
   import_playbook: aws_create_vpc.yaml 
 
 - name: '[AWS] create windows vm'


### PR DESCRIPTION
Summary of changes:
1. Named the task that uses the ec2_vpc_net_info module.
2. Increased the wait to 60 seconds to allow EC2 instances to reach Terminated state and stop being dependencies for the security groups.
3. Named the task that uses the ec2_group_info module.
4. Corrected the security group names, if they are not deleted then the VPC deletion will fail.
5. Corrected name for task that uses ec2_vpc_route_table module. 
