### PR TITLE
Using -U and -k for credentials is better.

### DIFF
--- a/chapter-03/aws/ping.yaml
+++ b/chapter-03/aws/ping.yaml
@@ -2,13 +2,8 @@
 - hosts: all
   gather_facts: false
 
-  vars_prompt:
-    - name: password
-      prompt: "Enter ansible user password"
-
   vars:
     ansible_user: ansible
-    ansible_password: "{{ password }}"
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
   tasks:

--- a/chapter-03/azure/ping.yaml
+++ b/chapter-03/azure/ping.yaml
@@ -2,13 +2,8 @@
 - hosts: all
   gather_facts: false
 
-  vars_prompt:
-    - name: password
-      prompt: "Enter ansible user password"
-
   vars:
     ansible_user: ansible
-    ansible_password: "{{ password }}"
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
   tasks:

--- a/chapter-06/configure_nginx_web_server.yml
+++ b/chapter-06/configure_nginx_web_server.yml
@@ -2,16 +2,7 @@
 - hosts: all
   gather_facts: false
 
-  vars_prompt:
-    - name: user
-      prompt: "Enter ssh user"
-      private: false
-    - name: password
-      prompt: "Enter password for ssh user"
-
   vars:
-    ansible_user: "{{ user }}"
-    ansible_password: "{{ password }}"
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
   tasks:

--- a/chapter-06/ping_prompts.yml
+++ b/chapter-06/ping_prompts.yml
@@ -2,15 +2,7 @@
 - hosts: all
   gather_facts: false
 
-  vars_prompt:
-    - name: user
-      prompt: "Enter ssh user"
-    - name: password
-      prompt: "Enter password for ssh user"
-
   vars:
-    ansible_user: "{{ user }}"
-    ansible_password: "{{ password }}"
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
   tasks:


### PR DESCRIPTION
Command line arguments are built-in to ansible, and are better supported by tools such as Tower and Jenkins ansible-plugin.

Fixes #29